### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 <img src="https://assets.picaos.com/github/pica-mcp.svg" alt="Pica MCP Banner" style="border-radius: 5px;">
 
+<a href="https://glama.ai/mcp/servers/@picahq/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@picahq/mcp/badge" alt="pica MCP server" />
+</a>
+
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that integrates with [Pica](https://picaos.com), enabling seamless interaction with various third-party services through a standardized interface. This server provides direct access to platform integrations, actions, execution capabilities, and robust code generation capabilities.
 
 ## Features
@@ -54,7 +58,6 @@ PICA_SECRET=your-pica-secret-key
 ```
 
 Get your Pica secret key from the [Pica dashboard](https://app.picaos.com/settings/api-keys).
-
 
 ## Usage
 


### PR DESCRIPTION
This PR adds a badge for the [pica](https://glama.ai/mcp/servers/@picahq/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@picahq/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@picahq/mcp/badge" alt="pica MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.